### PR TITLE
규칙 카테고리 수정 api 구현

### DIFF
--- a/src/controllers/RuleController.ts
+++ b/src/controllers/RuleController.ts
@@ -44,6 +44,44 @@ const createRuleCategory = async (
   }
 };
 
+/**
+ *  @route PUT /room/:roomId/rules/category/:categoryId
+ *  @desc Update RuleCategory
+ *  @access Private
+ */
+const updateRuleCategory = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void | Response> => {
+  const errors: Result<ValidationError> = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(
+        util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST, errors.array())
+      );
+  }
+
+  const ruleCategoryUpdateDto: RuleCategoryCreateDto = req.body;
+  const { roomId, categoryId } = req.params;
+
+  try {
+    const data = await RuleService.updateRuleCategory(
+      roomId,
+      categoryId,
+      ruleCategoryUpdateDto
+    );
+
+    return res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.UPDATE_RULE_CATEGORY, data));
+  } catch (error) {
+    next(error);
+  }
+};
+
 export default {
-  createRuleCategory
+  createRuleCategory,
+  updateRuleCategory
 };

--- a/src/controllers/RuleController.ts
+++ b/src/controllers/RuleController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { Result, ValidationError, validationResult } from 'express-validator';
 import { RuleCategoryCreateDto } from '../interfaces/rulecategory/RuleCategoryCreateDto';
+import { RuleCategoryUpdateDto } from '../interfaces/rulecategory/RuleCategoryUpdateDto';
 import message from '../modules/responseMessage';
 import statusCode from '../modules/statusCode';
 import util from '../modules/util';
@@ -37,7 +38,11 @@ const createRuleCategory = async (
     return res
       .status(statusCode.CREATED)
       .send(
-        util.success(statusCode.CREATED, message.CREATE_RULE_CATEGORY, data)
+        util.success(
+          statusCode.CREATED,
+          message.CREATE_RULE_CATEGORY_SUCCESS,
+          data
+        )
       );
   } catch (error) {
     next(error);
@@ -63,7 +68,7 @@ const updateRuleCategory = async (
       );
   }
 
-  const ruleCategoryUpdateDto: RuleCategoryCreateDto = req.body;
+  const ruleCategoryUpdateDto: RuleCategoryUpdateDto = req.body;
   const { roomId, categoryId } = req.params;
 
   try {
@@ -75,7 +80,9 @@ const updateRuleCategory = async (
 
     return res
       .status(statusCode.OK)
-      .send(util.success(statusCode.OK, message.UPDATE_RULE_CATEGORY, data));
+      .send(
+        util.success(statusCode.OK, message.UPDATE_RULE_CATEGORY_SUCCESS, data)
+      );
   } catch (error) {
     next(error);
   }

--- a/src/interfaces/rulecategory/RuleCategoryResponseDto.ts
+++ b/src/interfaces/rulecategory/RuleCategoryResponseDto.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 
 export interface RuleCategoryResponseDto {
-  _id: mongoose.Types.ObjectId;
+  _id: string;
   roomId: string;
   ruleCategoryName: string;
   ruleCategoryIcon: string;

--- a/src/interfaces/rulecategory/RuleCategoryUpdateDto.ts
+++ b/src/interfaces/rulecategory/RuleCategoryUpdateDto.ts
@@ -1,0 +1,4 @@
+export interface RuleCategoryUpdateDto {
+  categoryName: string;
+  categoryIcon: string;
+}

--- a/src/interfaces/rulecategory/RuleCategoryUpdateDto.ts
+++ b/src/interfaces/rulecategory/RuleCategoryUpdateDto.ts
@@ -1,4 +1,3 @@
-export interface RuleCategoryUpdateDto {
-  categoryName: string;
-  categoryIcon: string;
-}
+import { RuleCategoryCreateDto } from './RuleCategoryCreateDto';
+
+export interface RuleCategoryUpdateDto extends RuleCategoryCreateDto {}

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -34,8 +34,8 @@ const message = {
   // 규칙
   NOT_FOUND_RULE_CATEGORY: '존재하지 않는 규칙입니다.',
   CONFLICT_RULE_CATEGORY: '이미 존재하는 규칙 카테고리명입니다.',
-  CREATE_RULE_CATEGORY: '규칙 카테고리 생성 성공입니다.',
-  UPDATE_RULE_CATEGORY: '규칙 카테고리 수정 성공입니다.',
+  CREATE_RULE_CATEGORY_SUCCESS: '규칙 카테고리 생성 성공입니다.',
+  UPDATE_RULE_CATEGORY_SUCCESS: '규칙 카테고리 수정 성공입니다.',
 
   // 사용자
   READ_USER_SUCCESS: '사용자 정보 조회를 성공하였습니다.',

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -31,8 +31,10 @@ const message = {
   JOIN_ROOM_SUCCESS: '방 참가 성공입니다.',
 
   // 규칙
+  NOT_FOUND_RULE_CATEGORY: '존재하지 않는 규칙입니다.',
   CONFLICT_RULE_CATEGORY: '이미 존재하는 규칙 카테고리명입니다.',
   CREATE_RULE_CATEGORY: '규칙 카테고리 생성 성공입니다.',
+  UPDATE_RULE_CATEGORY: '규칙 카테고리 수정 성공입니다.',
 
   // 사용자
   READ_USER_SUCCESS: '사용자 정보 조회를 성공하였습니다.',

--- a/src/routes/RoomRouter.ts
+++ b/src/routes/RoomRouter.ts
@@ -26,4 +26,11 @@ router.post(
   RuleController.createRuleCategory
 );
 
+router.put(
+  '/:roomId/rules/category/:categoryId',
+  [body('categoryName').not().isEmpty(), body('categoryIcon').not().isEmpty()],
+  auth,
+  RuleController.updateRuleCategory
+);
+
 export default router;

--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -1,11 +1,10 @@
 import errorGenerator from '../errors/errorGenerator';
 import { RuleCategoryCreateDto } from '../interfaces/rulecategory/RuleCategoryCreateDto';
 import { RuleCategoryResponseDto } from '../interfaces/rulecategory/RuleCategoryResponseDto';
-import Room from '../models/Room';
+import { RuleCategoryUpdateDto } from '../interfaces/rulecategory/RuleCategoryUpdateDto';
 import RuleCategory from '../models/RuleCategory';
 import { checkObjectIdValidation } from '../modules/checkObjectIdValidation';
-import message from '../modules/responseMessage';
-import statusCode from '../modules/statusCode';
+import RuleServiceUtils from './RuleServiceUtils';
 
 const createRuleCategory = async (
   roomId: string,
@@ -16,24 +15,13 @@ const createRuleCategory = async (
     checkObjectIdValidation(roomId);
 
     // 방 존재 여부 확인
-    const existRoom = await Room.findById(roomId);
-    if (!existRoom)
-      throw errorGenerator({
-        msg: message.NOT_FOUND_ROOM,
-        statusCode: statusCode.NOT_FOUND
-      });
+    await RuleServiceUtils.findRoomById(roomId);
 
     // 규칙 카테고리명 중복 여부 확인
-    const conflictCategory = await RuleCategory.findOne({
-      roomId: roomId,
-      categoryName: ruleCategoryCreateDto.categoryName
-    });
-    if (conflictCategory) {
-      throw errorGenerator({
-        msg: message.CONFLICT_RULE_CATEGORY,
-        statusCode: statusCode.CONFLICT
-      });
-    }
+    await RuleServiceUtils.checkConflictRuleCategoryName(
+      roomId,
+      ruleCategoryCreateDto.categoryName
+    );
 
     const ruleCategory = new RuleCategory({
       roomId: roomId,
@@ -56,6 +44,46 @@ const createRuleCategory = async (
   }
 };
 
+const updateRuleCategory = async (
+  roomId: string,
+  categoryId: string,
+  ruleCategoryUpdateDto: RuleCategoryUpdateDto
+): Promise<RuleCategoryResponseDto | null> => {
+  try {
+    // roomId가 ObjectId 형식인지 확인
+    checkObjectIdValidation(roomId);
+
+    // categoryId가 ObjectId 형식인지 확인
+    checkObjectIdValidation(categoryId);
+
+    // 방 존재 여부 확인
+    await RuleServiceUtils.findRoomById(roomId);
+
+    // 규칙 카테고리 존재 여부 확인
+    await RuleServiceUtils.findRuleCategoryById(categoryId);
+
+    // 규칙 카테고리명 중복 여부 확인
+    await RuleServiceUtils.checkConflictRuleCategoryName(
+      roomId,
+      ruleCategoryUpdateDto.categoryName
+    );
+
+    await RuleCategory.findByIdAndUpdate(categoryId, ruleCategoryUpdateDto);
+
+    const data: RuleCategoryResponseDto = {
+      _id: categoryId,
+      roomId: roomId,
+      ruleCategoryName: ruleCategoryUpdateDto.categoryName,
+      ruleCategoryIcon: ruleCategoryUpdateDto.categoryIcon
+    };
+
+    return data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export default {
-  createRuleCategory
+  createRuleCategory,
+  updateRuleCategory
 };

--- a/src/services/RuleServiceUtils.ts
+++ b/src/services/RuleServiceUtils.ts
@@ -1,0 +1,53 @@
+import errorGenerator from '../errors/errorGenerator';
+import Room from '../models/Room';
+import RuleCategory from '../models/RuleCategory';
+import message from '../modules/responseMessage';
+import statusCode from '../modules/statusCode';
+
+// 방 존재 여부 확인
+const findRoomById = async (roomId: string) => {
+  const room = await Room.findById(roomId);
+  if (!room) {
+    throw errorGenerator({
+      msg: message.NOT_FOUND_ROOM,
+      statusCode: statusCode.NOT_FOUND
+    });
+  }
+  return room;
+};
+
+// 규칙 존재 여부 확인
+const findRuleCategoryById = async (categoryId: string) => {
+  const ruleCategory = await RuleCategory.findById(categoryId);
+  if (!ruleCategory) {
+    throw errorGenerator({
+      msg: message.NOT_FOUND_RULE_CATEGORY,
+      statusCode: statusCode.NOT_FOUND
+    });
+  }
+  return ruleCategory;
+};
+
+// 규칙 카테고리 중복 여부 확인
+const checkConflictRuleCategoryName = async (
+  roomId: string,
+  categoryName: string
+) => {
+  const category = await RuleCategory.findOne({
+    roomId: roomId,
+    categoryName: categoryName
+  });
+  if (category) {
+    throw errorGenerator({
+      msg: message.CONFLICT_RULE_CATEGORY,
+      statusCode: statusCode.CONFLICT
+    });
+  }
+  return category;
+};
+
+export default {
+  findRoomById,
+  findRuleCategoryById,
+  checkConflictRuleCategoryName
+};


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #28 

## 🔑 Key Changes
1. 내용
   - 규칙 카테고리 수정 api 구현

## 📢 To Reviewers
- 규칙 카테고리를 수정할 때 이름, 아이콘 둘다 받으려고 해서 RuleCategoryCreateDto랑 RuleCateogryUpdateDto의 내용이 같은 상황인데 파일을 따로 만들긴 했거든요,, 뭔가 Create이름 박혀있는걸 update로직에서 쓰기가 껄끄럽기도 하고 추후에 어떻게 될지 모르는 거니까? 혹시 여러분께서 주실 피드백이 있다면 환영입니다! 두개의 형식을 같이 둔건 어차피 클라에서 줄때도 수정한 값만 넘겨주기보다 아예 다 넣어서 넘겨주는게 편했던 것 같아 일단 그렇게 해놓았습니다! 이따 개발자회의때 물어보겠습니다!
- 그리고 RuleServiceUtils에 2번이상 반복되는 체크로직들 넣어놨는데 괜찮은지 피드백해주시길 바랍니다!
