### PR TITLE
#63 [feat] 규칙 1개 수정 api 구현

### DIFF
--- a/src/controllers/RuleController.ts
+++ b/src/controllers/RuleController.ts
@@ -3,6 +3,7 @@ import { Result, ValidationError, validationResult } from 'express-validator';
 import { RuleCreateDto } from '../interfaces/rule/RuleCreateDto';
 import { RuleReadInfoResponseDto } from '../interfaces/rule/RuleReadInfoResponseDto';
 import { RuleResponseDto } from '../interfaces/rule/RuleResponseDto';
+import { RuleUpdateDto } from '../interfaces/rule/RuleUpdateDto';
 import { RuleCategoryCreateDto } from '../interfaces/rulecategory/RuleCategoryCreateDto';
 import { RuleCategoryUpdateDto } from '../interfaces/rulecategory/RuleCategoryUpdateDto';
 import message from '../modules/responseMessage';
@@ -73,6 +74,45 @@ const getRuleByRuleId = async (
     return res
       .status(statusCode.OK)
       .send(util.success(statusCode.OK, message.READ_RULE_SUCCESS, data));
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ *  @route PUT /room/:roomId/rule/:ruleId
+ *  @desc Update Rule
+ *  @access Private
+ */
+const updateRule = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void | Response> => {
+  const errors: Result<ValidationError> = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res
+      .status(statusCode.BAD_REQUEST)
+      .send(
+        util.fail(statusCode.BAD_REQUEST, message.BAD_REQUEST, errors.array())
+      );
+  }
+
+  const userId: string = req.body.user._id;
+  const ruleUpdateDto: RuleUpdateDto = req.body;
+  const { roomId, ruleId } = req.params;
+
+  try {
+    const data: RuleResponseDto = await RuleService.updateRule(
+      userId,
+      roomId,
+      ruleId,
+      ruleUpdateDto
+    );
+
+    return res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.UPDATE_RULE_SUCCESS, data));
   } catch (error) {
     next(error);
   }
@@ -191,6 +231,7 @@ const getRuleCreateInfo = async (
 export default {
   createRule,
   getRuleByRuleId,
+  updateRule,
   createRuleCategory,
   updateRuleCategory,
   getRuleCreateInfo

--- a/src/interfaces/rule/RuleUpdateDto.ts
+++ b/src/interfaces/rule/RuleUpdateDto.ts
@@ -1,0 +1,3 @@
+import { RuleCreateDto } from './RuleCreateDto';
+
+export interface RuleUpdateDto extends RuleCreateDto {}

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -45,6 +45,7 @@ const message = {
 
   READ_RULE_SUCCESS: '규칙 조회 성공입니다.',
   CREATE_RULE_SUCCESS: '규칙 생성 성공입니다.',
+  UPDATE_RULE_SUCCESS: '규칙 수정 성공입니다.',
   CREATE_RULE_CATEGORY_SUCCESS: '규칙 카테고리 생성 성공입니다.',
   UPDATE_RULE_CATEGORY_SUCCESS: '규칙 카테고리 수정 성공입니다.',
   READ_RULE_CREATE_INFO_SUCCESS: '규칙 생성 시 조회 성공입니다.',

--- a/src/routes/RoomRouter.ts
+++ b/src/routes/RoomRouter.ts
@@ -45,9 +45,23 @@ router.post(
   auth,
   RuleController.createRule
 );
-router.get('/:roomId/rule/:ruleId', auth, RuleController.getRuleByRuleId);
-
 router.get('/:roomId/rule/new', auth, RuleController.getRuleCreateInfo);
+router.get('/:roomId/rule/:ruleId', auth, RuleController.getRuleByRuleId);
+router.put(
+  '/:roomId/rule/:ruleId',
+  [
+    body('notificationState').isBoolean(),
+    body('ruleName').isLength({
+      min: 1,
+      max: limitNum.RULE_NAME_MAX_LENGTH
+    }),
+    body('categoryId').not().isEmpty(),
+    body('isKeyRules').isBoolean(),
+    body('ruleMembers').isArray()
+  ],
+  auth,
+  RuleController.updateRule
+);
 
 /**
  * 규칙 카테고리

--- a/src/services/RuleServiceUtils.ts
+++ b/src/services/RuleServiceUtils.ts
@@ -54,6 +54,19 @@ const findRuleCategoryById = async (categoryId: string) => {
   return ruleCategory;
 };
 
+const checkConflictRuleName = async (roomId: string, ruleName: string) => {
+  const checkRules = await Rule.find({
+    roomId: roomId,
+    ruleName: ruleName
+  });
+  if (checkRules.length != 0) {
+    throw errorGenerator({
+      msg: message.CONFLICT_RULE_NAME,
+      statusCode: statusCode.CONFLICT
+    });
+  }
+};
+
 // 규칙 카테고리 중복 여부 확인
 const checkConflictRuleCategoryName = async (
   roomId: string,
@@ -77,5 +90,6 @@ export default {
   findRoomById,
   findRuleById,
   findRuleCategoryById,
+  checkConflictRuleName,
   checkConflictRuleCategoryName
 };


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #63

## 🔑 Key Changes
1. 규칙 수정 api 구현

## 📢 To Reviewers
- 마지막에 return 할 때 find를 한번 더하는데, 이 부분은 클라측에서 변경된 부분을 확인하고 싶다고 해서 이렇게 넣어뒀어요~ 나중에 릴리즈때는 204로 바꾸면 될 거 거같아유!
- updateOne은 return 형식이 findByIdAndUpdate랑 달라서 우선 이렇게 했습니당.
