### PR TITLE
유저 정보 수정 화면에서의 조회 api 구현 및 그외 자잘한 수정

### DIFF
--- a/src/controllers/EventController.ts
+++ b/src/controllers/EventController.ts
@@ -101,11 +101,11 @@ const deleteEvent = async (
   const { roomId, eventId } = req.params;
 
   try {
-    const data = await EventService.deleteEvent(userId, roomId, eventId);
+    await EventService.deleteEvent(userId, roomId, eventId);
 
     return res
       .status(statusCode.OK)
-      .send(util.success(statusCode.OK, message.DELETE_EVENT_SUCCESS, data));
+      .send(util.success(statusCode.OK, message.DELETE_EVENT_SUCCESS, null));
   } catch (error) {
     next(error);
   }

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -17,7 +17,7 @@ import { UserService } from '../services';
  * @desc Read User information at profile home View
  * @access Private
  */
-const getUser = async (
+const getUserAtHome = async (
   req: Request,
   res: Response,
   next: NextFunction

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,7 +1,8 @@
 import { NextFunction, Request, Response } from 'express';
 import { Result, ValidationError, validationResult } from 'express-validator';
 import { HomieResponseDto } from '../interfaces/user/HomieResponseDto';
-import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+import { UserModifyResponseDto } from '../interfaces/user/UserModifyResponseDto';
+import { UserProfileResponseDto } from '../interfaces/user/UserProfileResponseDto';
 import { UserSettingResponseDto } from '../interfaces/user/UserSettingResponseDto';
 import { UserUpdateDto } from '../interfaces/user/UserUpdateDto';
 import { UserUpdateResponseDto } from '../interfaces/user/UserUpdateResponseDto';
@@ -12,8 +13,8 @@ import util from '../modules/util';
 import { UserService } from '../services';
 
 /**
- * @route GET /user/profile/me
- * @desc select user information
+ * @route GET /user/profile
+ * @desc Read User information at profile home View
  * @access Private
  */
 const getUser = async (
@@ -24,7 +25,34 @@ const getUser = async (
   const userId: string = req.body.user._id;
 
   try {
-    const data: UserResponseDto = await UserService.getUser(userId);
+    const data: UserProfileResponseDto = await UserService.getUserAtHome(
+      userId
+    );
+
+    return res
+      .status(statusCode.OK)
+      .send(util.success(statusCode.OK, message.READ_USER_SUCCESS, data));
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @route POST /user/profile/me
+ * @desc Read User information at profile modify View
+ * @access Private
+ */
+const getUserAtModify = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void | Response> => {
+  const userId: string = req.body.user._id;
+
+  try {
+    const data: UserModifyResponseDto = await UserService.getUserAtModify(
+      userId
+    );
 
     return res
       .status(statusCode.OK)
@@ -153,7 +181,8 @@ const getHomieProfile = async (
 };
 
 export default {
-  getUser,
+  getUserAtHome,
+  getUserAtModify,
   updateUser,
   getUserSetting,
   getHomieProfile,

--- a/src/interfaces/user/HomieResponseDto.ts
+++ b/src/interfaces/user/HomieResponseDto.ts
@@ -1,3 +1,3 @@
-import { UserBaseResponseDto } from './UserResponseDto';
+import { TypeDto, UserBaseResponseDto } from './UserProfileResponseDto';
 
-export interface HomieResponseDto extends UserBaseResponseDto {}
+export interface HomieResponseDto extends UserBaseResponseDto, TypeDto {}

--- a/src/interfaces/user/UserModifyResponseDto.ts
+++ b/src/interfaces/user/UserModifyResponseDto.ts
@@ -1,0 +1,3 @@
+import { TypeDto, UserBaseResponseDto } from './UserProfileResponseDto';
+
+export interface UserModifyResponseDto extends UserBaseResponseDto, TypeDto {}

--- a/src/interfaces/user/UserProfileResponseDto.ts
+++ b/src/interfaces/user/UserProfileResponseDto.ts
@@ -1,4 +1,4 @@
-export interface UserResponseDto extends UserBaseResponseDto {
+export interface UserProfileResponseDto extends UserBaseResponseDto, TypeDto {
   notificationState: boolean;
 }
 
@@ -7,7 +7,10 @@ export interface UserBaseResponseDto {
   job: string;
   introduction: string;
   hashTag: string[];
+}
+
+export interface TypeDto {
   typeName: string;
   typeColor: string;
-  typeScore: number[];
+  typeScore?: number[];
 }

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -11,7 +11,8 @@ router.get('/:homieId', auth, UserController.getHomieProfile);
 /**
  * 프로필
  */
-router.get('/profile/me', auth, UserController.getUser);
+router.get('/profile', auth, UserController.getUserAtHome);
+router.get('/profile/me', auth, UserController.getUserAtModify);
 router.put(
   '/profile/me',
   [

--- a/src/routes/UserRouter.ts
+++ b/src/routes/UserRouter.ts
@@ -6,8 +6,6 @@ import limitNum from '../modules/limitNum';
 
 const router: Router = Router();
 
-router.get('/:homieId', auth, UserController.getHomieProfile);
-
 /**
  * 프로필
  */
@@ -35,5 +33,10 @@ router.put(
   auth,
   UserController.updateUserNotificationState
 );
+
+/**
+ * 룸메이트 조회 (홈화면에서 호미 클릭 시)
+ */
+router.get('/:homieId', auth, UserController.getHomieProfile);
 
 export default router;

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs';
-import { PostBaseResponseDto } from '../interfaces/common/PostBaseResponseDto';
 import { EventCreateDto } from '../interfaces/event/EventCreateDto';
 import { EventCreateResponseDto } from '../interfaces/event/EventCreateResponseDto';
 import { EventUpdateDto } from '../interfaces/event/EventUpdateDto';
@@ -130,7 +129,7 @@ const deleteEvent = async (
   userId: string,
   roomId: string,
   eventId: string
-): Promise<PostBaseResponseDto> => {
+): Promise<void> => {
   try {
     // 유저 확인
     const user = await EventServiceUtils.findUserById(userId);
@@ -156,11 +155,6 @@ const deleteEvent = async (
     await Event.findByIdAndDelete(eventId);
 
     await room.updateOne({ eventCnt: room.eventCnt - 1 });
-
-    const data: PostBaseResponseDto = {
-      _id: event._id
-    };
-    return data;
   } catch (error) {
     throw error;
   }

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -89,7 +89,7 @@ const updateEvent = async (
     // 이벤트 존재 여부 확인
     const event = await EventServiceUtil.findEventById(eventId);
 
-    // 참여하고 있는 방의 이벤트인지 확인
+    // 참가하고 있는 방의 이벤트가 아니면 접근 불가능
     await EventServiceUtil.checkForbiddenEvent(user.roomId, event.roomId);
 
     // 참여자 개수가 방 인원의 수가 넘는지 확인
@@ -141,8 +141,8 @@ const deleteEvent = async (
     // 이벤트 존재 여부 확인
     const event = await EventServiceUtil.findEventById(eventId);
 
-    // 참여하고 있는 방의 이벤트인지 확인
-    await EventServiceUtil.checkForbiddenEvent(user.roomId, event._id);
+    // 참가하고 있는 방의 이벤트가 아니면 접근 불가능
+    await EventServiceUtil.checkForbiddenEvent(user.roomId, event.roomId);
 
     await Event.findByIdAndDelete(eventId);
 

--- a/src/services/EventService.ts
+++ b/src/services/EventService.ts
@@ -8,7 +8,7 @@ import Event from '../models/Event';
 import checkObjectIdValidation from '../modules/checkObjectIdValidation';
 import checkValidUtils from '../modules/checkValidUtils';
 import limitNum from '../modules/limitNum';
-import EventServiceUtil from './EventServiceUtils';
+import EventServiceUtils from './EventServiceUtils';
 
 const createEvent = async (
   userId: string,
@@ -17,13 +17,16 @@ const createEvent = async (
 ): Promise<EventCreateResponseDto> => {
   try {
     // 유저 확인
-    await EventServiceUtil.findUserById(userId);
+    const user = await EventServiceUtils.findUserById(userId);
 
     // roomId ObjectId 형식인지 확인
     checkObjectIdValidation(roomId);
 
     // 방 존재 여부 확인
-    const room = await EventServiceUtil.findRoomById(roomId);
+    const room = await EventServiceUtils.findRoomById(roomId);
+
+    // 참가하고 있는 방이 아니면 접근 불가능
+    await EventServiceUtils.checkForbiddenRoom(user.roomId, room._id);
 
     // event 개수 확인
     checkValidUtils.checkCountLimit(room.eventCnt, limitNum.EVENT_CNT);
@@ -75,7 +78,7 @@ const updateEvent = async (
 ): Promise<EventUpdateResponseDto> => {
   try {
     // 유저 확인
-    const user = await EventServiceUtil.findUserById(userId);
+    const user = await EventServiceUtils.findUserById(userId);
 
     // roomId ObjectId 형식인지 확인
     checkObjectIdValidation(roomId);
@@ -84,13 +87,16 @@ const updateEvent = async (
     checkObjectIdValidation(eventId);
 
     // 방 존재 여부 확인
-    const room = await EventServiceUtil.findRoomById(roomId);
+    const room = await EventServiceUtils.findRoomById(roomId);
 
     // 이벤트 존재 여부 확인
-    const event = await EventServiceUtil.findEventById(eventId);
+    const event = await EventServiceUtils.findEventById(eventId);
+
+    // 참가하고 있는 방이 아니면 접근 불가능
+    await EventServiceUtils.checkForbiddenRoom(user.roomId, room._id);
 
     // 참가하고 있는 방의 이벤트가 아니면 접근 불가능
-    await EventServiceUtil.checkForbiddenEvent(user.roomId, event.roomId);
+    await EventServiceUtils.checkForbiddenEvent(user.roomId, event.roomId);
 
     // 참여자 개수가 방 인원의 수가 넘는지 확인
     checkValidUtils.checkArraySize(
@@ -127,7 +133,7 @@ const deleteEvent = async (
 ): Promise<PostBaseResponseDto> => {
   try {
     // 유저 확인
-    const user = await EventServiceUtil.findUserById(userId);
+    const user = await EventServiceUtils.findUserById(userId);
 
     // roomId ObjectId 형식인지 확인
     checkObjectIdValidation(roomId);
@@ -136,13 +142,16 @@ const deleteEvent = async (
     checkObjectIdValidation(eventId);
 
     // 방 존재 여부 확인
-    const room = await EventServiceUtil.findRoomById(roomId);
+    const room = await EventServiceUtils.findRoomById(roomId);
 
     // 이벤트 존재 여부 확인
-    const event = await EventServiceUtil.findEventById(eventId);
+    const event = await EventServiceUtils.findEventById(eventId);
+
+    // 참가하고 있는 방이 아니면 접근 불가능
+    await EventServiceUtils.checkForbiddenRoom(user.roomId, room._id);
 
     // 참가하고 있는 방의 이벤트가 아니면 접근 불가능
-    await EventServiceUtil.checkForbiddenEvent(user.roomId, event.roomId);
+    await EventServiceUtils.checkForbiddenEvent(user.roomId, event.roomId);
 
     await Event.findByIdAndDelete(eventId);
 

--- a/src/services/EventServiceUtils.ts
+++ b/src/services/EventServiceUtils.ts
@@ -51,9 +51,22 @@ const checkForbiddenEvent = async (
   }
 };
 
+const checkForbiddenRoom = async (
+  userRoomId: mongoose.Types.ObjectId,
+  roomId: mongoose.Types.ObjectId
+) => {
+  if (!userRoomId.equals(roomId)) {
+    throw errorGenerator({
+      msg: message.FORBIDDEN_ROOM,
+      statusCode: statusCode.FORBIDDEN
+    });
+  }
+};
+
 export default {
   findUserById,
   findRoomById,
   findEventById,
-  checkForbiddenEvent
+  checkForbiddenEvent,
+  checkForbiddenRoom
 };

--- a/src/services/RoomService.ts
+++ b/src/services/RoomService.ts
@@ -203,8 +203,8 @@ const getRoomInfoAtHome = async (
     });
 
     const keyRulesList: string[] = await Promise.all(
-      tmpKeyRulesList.map(async (KeyRules: any) => {
-        return KeyRules.ruleName;
+      tmpKeyRulesList.map(async (keyRule: any) => {
+        return keyRule.ruleName;
       })
     );
 

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -3,7 +3,8 @@ import errorGenerator from '../errors/errorGenerator';
 import { SignupDto } from '../interfaces/auth/SignupDto';
 import { PostBaseResponseDto } from '../interfaces/common/PostBaseResponseDto';
 import { HomieResponseDto } from '../interfaces/user/HomieResponseDto';
-import { UserResponseDto } from '../interfaces/user/UserResponseDto';
+import { UserModifyResponseDto } from '../interfaces/user/UserModifyResponseDto';
+import { UserProfileResponseDto } from '../interfaces/user/UserProfileResponseDto';
 import { UserSettingResponseDto } from '../interfaces/user/UserSettingResponseDto';
 import { UserUpdateDto } from '../interfaces/user/UserUpdateDto';
 import { UserUpdateResponseDto } from '../interfaces/user/UserUpdateResponseDto';
@@ -55,7 +56,9 @@ const createUser = async (
   }
 };
 
-const getUser = async (userId: string): Promise<UserResponseDto> => {
+const getUserAtHome = async (
+  userId: string
+): Promise<UserProfileResponseDto> => {
   try {
     await UserServiceUtils.findUserById(userId);
 
@@ -71,7 +74,7 @@ const getUser = async (userId: string): Promise<UserResponseDto> => {
       });
     }
 
-    const data: UserResponseDto = {
+    const data: UserProfileResponseDto = {
       userName: userInfo.userName,
       job: userInfo.job,
       introduction: userInfo.introduction,
@@ -80,6 +83,39 @@ const getUser = async (userId: string): Promise<UserResponseDto> => {
       typeColor: (userInfo.typeId as any).typeColor,
       typeScore: userInfo.typeScore,
       notificationState: userInfo.notificationState
+    };
+
+    return data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const getUserAtModify = async (
+  userId: string
+): Promise<UserModifyResponseDto> => {
+  try {
+    await UserServiceUtils.findUserById(userId);
+
+    const userInfo = await User.findById(userId).populate(
+      'typeId',
+      'typeName typeColor'
+    );
+
+    if (!userInfo) {
+      throw errorGenerator({
+        msg: message.NOT_FOUND_USER,
+        statusCode: statusCode.NOT_FOUND
+      });
+    }
+
+    const data: UserModifyResponseDto = {
+      userName: userInfo.userName,
+      job: userInfo.job,
+      introduction: userInfo.introduction,
+      hashTag: userInfo.hashTag,
+      typeName: (userInfo.typeId as any).typeName,
+      typeColor: (userInfo.typeId as any).typeColor
     };
 
     return data;
@@ -203,7 +239,8 @@ const updateUserNotificationState = async (
 export default {
   createUser,
   updateUser,
-  getUser,
+  getUserAtHome,
+  getUserAtModify,
   getUserSetting,
   getHomieProfile,
   updateUserNotificationState


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #78

## 🔑 Key Changes
1. 프로필 홈화면 조회 endpoint 및 함수명 변경, 주석 추가 
2. 프로필 수정 화면에서의 조회 api 구현
3. 프로필 쪽 resposeDto가 전달해주는 형태가 비슷비슷해서 dto를 전반적으로 수정

## 📢 To Reviewers
- 제가 프로필 쪽 api 헷갈리게 해서 죄송합니다. 포항항.. 저도 헷갈렸네요 .. ~
