### PR TITLE
규칙 생성/삭제, 규칙 카테고리 삭제 api 수정 (규칙 개수 제한)

### DIFF
--- a/src/interfaces/room/RoomInfo.ts
+++ b/src/interfaces/room/RoomInfo.ts
@@ -6,5 +6,4 @@ export interface RoomInfo {
   userCnt: number;
   eventCnt: number;
   ruleCategoryCnt: number;
-  ruleCnt: number;
 }

--- a/src/interfaces/rulecategory/RuleCategoryInfo.ts
+++ b/src/interfaces/rulecategory/RuleCategoryInfo.ts
@@ -4,4 +4,5 @@ export interface RuleCategoryInfo {
   roomId: mongoose.Types.ObjectId;
   categoryName: string;
   categoryIcon: string;
+  ruleCnt: number;
 }

--- a/src/interfaces/rulecategory/RuleCategoryResponseDto.ts
+++ b/src/interfaces/rulecategory/RuleCategoryResponseDto.ts
@@ -5,4 +5,5 @@ export interface RuleCategoryResponseDto {
   roomId: string;
   ruleCategoryName: string;
   ruleCategoryIcon: string;
+  ruleCnt: number;
 }

--- a/src/models/Room.ts
+++ b/src/models/Room.ts
@@ -27,11 +27,6 @@ const RoomSchema = new mongoose.Schema(
       type: Number,
       required: false,
       default: 1
-    },
-    ruleCnt: {
-      type: Number,
-      required: false,
-      default: 0
     }
   },
   {

--- a/src/models/RuleCategory.ts
+++ b/src/models/RuleCategory.ts
@@ -15,6 +15,11 @@ const RuleCategorySchema = new mongoose.Schema(
     categoryIcon: {
       type: String,
       required: true
+    },
+    ruleCnt: {
+      type: Number,
+      required: false,
+      default: 0
     }
   },
   {

--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -530,10 +530,9 @@ const deleteRuleCategory = async (
     // 해당 규칙 카테고리 삭제
     await ruleCategory.deleteOne();
 
-    // 방의 규칙 카테고리 개수 -1, 규책 개수 - 삭제된 규칙 개수
+    // 방의 규칙 카테고리 개수 -1
     await room.updateOne({
-      ruleCategoryCnt: room.ruleCategoryCnt - 1,
-      ruleCnt: room.ruleCnt - deletedRules.deletedCount
+      ruleCategoryCnt: room.ruleCategoryCnt - 1
     });
   } catch (error) {
     throw error;

--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -423,7 +423,8 @@ const createRuleCategory = async (
       _id: ruleCategory._id,
       roomId: roomId,
       ruleCategoryName: ruleCategory.categoryName,
-      ruleCategoryIcon: ruleCategory.categoryIcon
+      ruleCategoryIcon: ruleCategory.categoryIcon,
+      ruleCnt: ruleCategory.ruleCnt
     };
 
     return data;
@@ -480,7 +481,8 @@ const updateRuleCategory = async (
       _id: categoryId,
       roomId: roomId,
       ruleCategoryName: ruleCategoryUpdateDto.categoryName,
-      ruleCategoryIcon: ruleCategoryUpdateDto.categoryIcon
+      ruleCategoryIcon: ruleCategoryUpdateDto.categoryIcon,
+      ruleCnt: ruleCategory.ruleCnt
     };
 
     return data;

--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -266,6 +266,17 @@ const updateRule = async (
     // 참가하고 있는 방의 규칙이 아니면 접근 불가능
     await RuleServiceUtils.checkForbiddenRule(user.roomId, rule.roomId);
 
+    // 규칙 카테고리 존재 여부 확인
+    const ruleCategory = await RuleServiceUtils.findRuleCategoryById(
+      ruleUpdateDto.categoryId
+    );
+
+    // 참가하고 있는 방의 규칙 카테고리가 아니면 접근 불가능
+    await RuleServiceUtils.checkForbiddenRuleCategory(
+      user.roomId,
+      ruleCategory.roomId
+    );
+
     // 규칙 이름 중복 체크
     if (rule.ruleName != ruleUpdateDto.ruleName) {
       await RuleServiceUtils.checkConflictRuleName(


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #86

## 🔑 Key Changes
1. 한 방의 규칙 개수 제한 -> 카테고리별 규칙 개수 제한으로 수정
- Room, RoomInfo : ruleCnt 삭제
- RuleCategory, RuleCategoryInfo : ruleCnt 추가
- 규칙 추가/삭제, 규칙 카테고리 추가/삭제 시 카테고리 별 규칙 개수 확인
  - RuleService.createRule 수정
    - 규칙 생성 개수 제한 수정 -> 카테고리별 제한 20개
    - 카테고리 id 존재하는지, 카테고리가 room에 포함되는지 확인 _(updateRule에도 추가했음)_
    - 규칙 카테고리의 ruleCnt + 1
  - RuleService.deleteRule 수정
    - 규칙 카테고리의 ruleCnt - 1
  - RuleService.deleteRuleCategory 수정
    - room의 ruleCnt 수정하는 부분 삭제
    - ruleCnt가 규칙 카테고리에 있으므로 삭제에서는 규칙 개수 수정은 안해줘도 됨.
    (어차피 규칙카테고리자체가 삭제될 것이므로)
  - RuleService.createRuleCategory 수정
    - RuleCategoryResponseDto에 ruleCnt 추가
  - RuleService.updateRuleCategory 수정
    - RuleCategoryResponseDto에 ruleCnt 추가



## 📢 To Reviewers
- postman 돌려보고 확인하긴했는데 코드리뷰로 틀린부분있는지 확인 부탁드립니다!
- To 혁준. 카테고리 존재여부/접근권한에 대한 에러결과들 `규칙추가` `규칙수정` api 명세서에 추가해놨습니다!
