### PR TITLE
 #89 [fix] 이벤트 추가/수정 시 참여자 목록 빈 값인지 검증 추가

### DIFF
--- a/src/routes/RoomRouter.ts
+++ b/src/routes/RoomRouter.ts
@@ -17,13 +17,13 @@ router.get('/', auth, RoomController.getRoom);
 router.post('/', auth, RoomController.createRoom);
 router.get(
   '/in',
-  [body('roomCode').notEmpty()],
+  [body('roomCode').not().isEmpty()],
   auth,
   RoomController.getRoomAndUserByRoomCode
 );
 router.post(
   '/:roomId/in',
-  [body('roomCode').notEmpty()],
+  [body('roomCode').not().isEmpty()],
   auth,
   RoomController.joinRoom
 );
@@ -71,12 +71,11 @@ router.delete('/:roomId/rule/:ruleId', auth, RuleController.deleteRule);
 router.post(
   '/:roomId/rules/category',
   [
-    body('categoryName').not().isEmpty(),
-    body('categoryIcon').not().isEmpty(),
-    body('categoryName').isLength({
+    body('categoryName').not().isEmpty().isLength({
       min: 1,
       max: limitNum.RULE_CATEGORY_NAME_MAX_LENGTH
-    })
+    }),
+    body('categoryIcon').not().isEmpty()
   ],
   auth,
   RuleController.createRuleCategory
@@ -84,7 +83,13 @@ router.post(
 
 router.put(
   '/:roomId/rules/category/:categoryId',
-  [body('categoryName').not().isEmpty(), body('categoryIcon').not().isEmpty()],
+  [
+    body('categoryName').not().isEmpty().isLength({
+      min: 1,
+      max: limitNum.RULE_CATEGORY_NAME_MAX_LENGTH
+    }),
+    body('categoryIcon').not().isEmpty()
+  ],
   auth,
   RuleController.updateRuleCategory
 );
@@ -107,7 +112,7 @@ router.post(
       .isLength({ min: 1, max: limitNum.EVENT_NAME_MAX_LENGTH }),
     body('eventIcon').not().isEmpty(),
     body('date').not().isEmpty(),
-    body('participants').isArray()
+    body('participants').not().isEmpty().isArray()
   ],
   auth,
   EventController.createEvent


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #89

## 🔑 Key Changes
1. 혁준이가 찾아준 휴먼에러를 고쳤습니다.

## 📢 To Reviewers
- isArray()에도 not().empty()를 붙여주면 빈배열이 못오도록 할 수 있네요 ... !!!!
```
{
    "status": 400,
    "success": false,
    "message": "잘못된 요청입니다.",
    "error": [
        {
            "value": [],
            "msg": "Invalid value",
            "param": "participants",
            "location": "body"
        }
    ]
}
```

붙이는 김에 router 단에 검증 추가해도 되는지 ... 
- 규칙 카테고리 생성/수정 시에도 붙여도 될까요?
   - 수정 시에 카테고리명에 대해서 length부분도 추가해도 될까요? 
- 규칙 생성/수정 시 isKeyRules와 ruleMembers에도 추가해도 될까요?

