### PR TITLE
#87 [fix] 홈조회 시 이벤트 내 모든 내용 보이도록 수정

### DIFF
--- a/src/interfaces/event/EventCreateResponseDto.ts
+++ b/src/interfaces/event/EventCreateResponseDto.ts
@@ -1,6 +1,3 @@
-import { PostBaseResponseDto } from '../common/PostBaseResponseDto';
-import { EventCreateDto } from './EventCreateDto';
+import { EventResponseDto } from './EventResponseDto';
 
-export interface EventCreateResponseDto
-  extends PostBaseResponseDto,
-    EventCreateDto {}
+export interface EventCreateResponseDto extends EventResponseDto {}

--- a/src/interfaces/event/EventResponseDto.ts
+++ b/src/interfaces/event/EventResponseDto.ts
@@ -1,0 +1,4 @@
+import { PostBaseResponseDto } from '../common/PostBaseResponseDto';
+import { EventCreateDto } from './EventCreateDto';
+
+export interface EventResponseDto extends PostBaseResponseDto, EventCreateDto {}

--- a/src/interfaces/event/EventUpdateResponseDto.ts
+++ b/src/interfaces/event/EventUpdateResponseDto.ts
@@ -1,6 +1,3 @@
-import { PostBaseResponseDto } from '../common/PostBaseResponseDto';
-import { EventCreateDto } from './EventCreateDto';
+import { EventResponseDto } from './EventResponseDto';
 
-export interface EventUpdateResponseDto
-  extends PostBaseResponseDto,
-    EventCreateDto {}
+export interface EventUpdateResponseDto extends EventResponseDto {}

--- a/src/interfaces/room/HomeResponseDto.ts
+++ b/src/interfaces/room/HomeResponseDto.ts
@@ -1,3 +1,5 @@
+import { EventResponseDto } from '../event/EventResponseDto';
+
 export interface HomeResponseDto {
   eventList: EventsInfo[];
   keyRulesList: string[];
@@ -6,11 +8,8 @@ export interface HomeResponseDto {
   roomCode: string;
 }
 
-export interface EventsInfo {
-  _id: string;
+export interface EventsInfo extends EventResponseDto {
   dDay: string;
-  eventName: string;
-  eventIcon: string;
 }
 
 export interface TodoInfo {

--- a/src/interfaces/room/HomeResponseDto.ts
+++ b/src/interfaces/room/HomeResponseDto.ts
@@ -16,6 +16,7 @@ export interface EventsInfo {
 export interface TodoInfo {
   isCheck: boolean;
   todo: string;
+  createdAt: Date;
 }
 
 export interface HomieProfile {

--- a/src/services/RoomService.ts
+++ b/src/services/RoomService.ts
@@ -286,6 +286,8 @@ const getRoomInfoAtHome = async (
           _id: event._id,
           eventName: event.eventName,
           eventIcon: event.eventIcon,
+          date: event.date,
+          participants: event.participantsId,
           dDay: eventDday.toString()
         };
         return result;


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #87 

## 🔑 Key Changes
1. 기존에 규칙 부분에서 모든 규칙을 가져오는 코드 -> '오늘' && '나'의 담당 규칙만 보이도록 수정 
2. 이벤트에 모든 내용을 보여주도록 수정
3. 이벤트 조회 api 추가에 따라 interface 추가 생성 

## 📢 To Reviewers
- RoomService.ts 파일에서 고정담당자/임시담당자 오늘, 나인 경우를 찾는 부분을 연주언니와 함께 머리를 굴려가며 다음과 같이 코딩했는데 .. 최선인 것 같습니다 ....... 
- 규칙을 현재는 createdAt을 포함하여 전달 중인데 이 부분은 빼서 주면 참으로 좋으련만 그것이 안되네요 .... 
- 코리로 피드백 주시면 감사하겠습니다!
