### PR TITLE
#82 [feat] 규칙 홈 조회 api 구현

### DIFF
--- a/src/controllers/RuleController.ts
+++ b/src/controllers/RuleController.ts
@@ -3,6 +3,7 @@ import { Result, ValidationError, validationResult } from 'express-validator';
 import { HomiesWithIsTmpMemberResponseDto } from '../interfaces/rule/HomiesWithIsTmpMemberResponseDto';
 import { RuleCreateDto } from '../interfaces/rule/RuleCreateDto';
 import { RuleCreateInfoResponseDto } from '../interfaces/rule/RuleCreateInfoResponseDto';
+import { RuleHomeResponseDto } from '../interfaces/rule/RuleHomeResponseDto';
 import { RuleMyTodoResponseDto } from '../interfaces/rule/RuleMyTodoResponseDto';
 import { RuleReadInfoResponseDto } from '../interfaces/rule/RuleReadInfoResponseDto';
 import { RuleResponseDto } from '../interfaces/rule/RuleResponseDto';
@@ -425,6 +426,39 @@ const getMyRuleInfo = async (
   }
 };
 
+/**
+ *  @route GET /room/:roomId/rules
+ *  @desc Read rule info at rule home view
+ *  @access Private
+ */
+const getRuleInfoAtRuleHome = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void | Response> => {
+  const userId: string = req.body.user._id;
+  const { roomId } = req.params;
+
+  try {
+    const data: RuleHomeResponseDto = await RuleService.getRuleInfoAtRuleHome(
+      userId,
+      roomId
+    );
+
+    return res
+      .status(statusCode.OK)
+      .send(
+        util.success(
+          statusCode.OK,
+          message.READ_RULE_AT_RULE_HOME_SUCCESS,
+          data
+        )
+      );
+  } catch (error) {
+    next(error);
+  }
+};
+
 export default {
   createRule,
   getRuleByRuleId,
@@ -437,5 +471,6 @@ export default {
   getRulesByCategoryId,
   getHomiesWithIsTmpMember,
   updateTmpRuleMembers,
-  getMyRuleInfo
+  getMyRuleInfo,
+  getRuleInfoAtRuleHome
 };

--- a/src/interfaces/room/HomeResponseDto.ts
+++ b/src/interfaces/room/HomeResponseDto.ts
@@ -13,8 +13,8 @@ export interface EventsResponseDto extends EventResponseDto {
 }
 
 export interface TodoResponseDto {
-  existCheck: boolean;
-  todoName: string;
+  isChecked: boolean;
+  ruleName: string;
 }
 
 export interface TodoWithDate extends TodoResponseDto {

--- a/src/interfaces/rule/RuleHomeResponseDto.ts
+++ b/src/interfaces/rule/RuleHomeResponseDto.ts
@@ -1,0 +1,32 @@
+import mongoose from 'mongoose';
+
+export interface RuleHomeResponseDto {
+  ruleCategories: RuleCategories[];
+  todayTodoRules: TodayTodoRules[];
+}
+
+export interface RuleCategories {
+  categoryName: string;
+  categoryIcon: string;
+}
+
+export interface TodayTodoRules {
+  _id: mongoose.Types.ObjectId;
+  ruleName: string;
+  todayMembersWithTypeColor: TodayMembersWithTypeColor[];
+  isDiff: boolean;
+}
+
+export interface TodayTodoRulesWithDate extends TodayTodoRules {
+  createdAt: Date;
+}
+
+export interface TodayMembersWithTypeColor {
+  userName: string;
+  typeColor: string;
+}
+
+export interface TodayMembersWithTypeColorWithDate
+  extends TodayMembersWithTypeColor {
+  typeUpdatedDate: Date;
+}

--- a/src/interfaces/rule/RuleHomeResponseDto.ts
+++ b/src/interfaces/rule/RuleHomeResponseDto.ts
@@ -1,20 +1,26 @@
 import mongoose from 'mongoose';
 
 export interface RuleHomeResponseDto {
-  ruleCategories: RuleCategories[];
+  homeRuleCategories: HomeRuleCategories[];
   todayTodoRules: TodayTodoRules[];
 }
 
-export interface RuleCategories {
+export interface HomeRuleCategories {
+  _id: mongoose.Types.ObjectId;
   categoryName: string;
   categoryIcon: string;
+}
+
+export interface HomeRuleCategoriesWithDate extends HomeRuleCategories {
+  createdAt: Date;
 }
 
 export interface TodayTodoRules {
   _id: mongoose.Types.ObjectId;
   ruleName: string;
   todayMembersWithTypeColor: TodayMembersWithTypeColor[];
-  isDiff: boolean;
+  isTmpMember: boolean;
+  isAllChecked: boolean;
 }
 
 export interface TodayTodoRulesWithDate extends TodayTodoRules {

--- a/src/interfaces/rulecategory/RuleCategoryResponseDto.ts
+++ b/src/interfaces/rulecategory/RuleCategoryResponseDto.ts
@@ -1,9 +1,10 @@
-import mongoose from 'mongoose';
-
-export interface RuleCategoryResponseDto {
-  _id: string;
+export interface RuleCategoryResponseDto extends RuleCategoryBaseDto {
   roomId: string;
+  ruleCnt: number;
+}
+
+export interface RuleCategoryBaseDto {
+  _id: string;
   ruleCategoryName: string;
   ruleCategoryIcon: string;
-  ruleCnt: number;
 }

--- a/src/modules/responseMessage.ts
+++ b/src/modules/responseMessage.ts
@@ -30,6 +30,7 @@ const message = {
 
   // 홈
   READ_ROOM_AT_HOME_SUCCESS: '홈화면 조회 성공입니다.',
+  READ_RULE_AT_RULE_HOME_SUCCESS: '규칙 홈화면 조회 성공입니다.',
 
   // 방
   NOT_FOUND_ROOM: '존재하지 않는 방입니다.',

--- a/src/routes/RoomRouter.ts
+++ b/src/routes/RoomRouter.ts
@@ -156,5 +156,6 @@ router.delete('/:roomId/event/:eventId', auth, EventController.deleteEvent);
  * 홈
  */
 router.get('/:roomId/home', auth, RoomController.getRoomInfoAtHome);
+router.get('/:roomId/rules', auth, RuleController.getRuleInfoAtRuleHome);
 
 export default router;

--- a/src/services/RoomService.ts
+++ b/src/services/RoomService.ts
@@ -397,25 +397,24 @@ const checkTodoListForCheckStatus = async (
   userId: string
 ): Promise<TodoWithDate> => {
   let checkStatus: boolean;
-  const existCheck = await Check.findOne({
+  const checks = await Check.find({
     ruleId: rule._id,
     userId: userId
   });
 
-  if (!existCheck) {
-    return {
-      existCheck: false,
-      todoName: rule.ruleName,
-      createdAt: dayjs(rule.createdAt).add(9, 'hour').format()
-    };
-  } else {
-    const existCheckDate = dayjs(existCheck.date);
-    checkStatus = existCheckDate.isSame(dayjs()) ? true : false;
+  let isChecked: boolean = false;
+
+  for (const check of checks) {
+    if (dayjs().isSame(check.date, 'day')) {
+      isChecked = true;
+      break;
+    }
   }
+
   return {
-    existCheck: checkStatus,
-    todoName: rule.ruleName,
-    createdAt: dayjs(rule.createdAt).add(9, 'hour').format()
+    isChecked: isChecked,
+    ruleName: rule.ruleName,
+    createdAt: rule.createdAt
   };
 };
 

--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -1100,6 +1100,8 @@ const getRuleInfoAtRuleHome = async (
         const originalTodayMembers: string[] = [];
         await Promise.all(
           rule.ruleMembers.map(async (ruleMember: any) => {
+            console.log(ruleMember.userId);
+            console.log(ruleMember.day);
             if (ruleMember.day.includes(dayjs().day())) {
               originalTodayMembers.push(ruleMember.userId);
             }
@@ -1108,6 +1110,8 @@ const getRuleInfoAtRuleHome = async (
 
         let isTmpMember = false;
         const todayMembersWithTypeColorWithDate: TodayMembersWithTypeColorWithDate[] =
+          [];
+        const todayMembersWithTypeColorNoDate: TodayMembersWithTypeColorWithDate[] =
           [];
         let isAllChecked: boolean = false;
         let checkCnt: number = 0;
@@ -1135,11 +1139,21 @@ const getRuleInfoAtRuleHome = async (
                 }
               }
 
-              todayMembersWithTypeColorWithDate.push({
-                userName: tmpMember.userName,
-                typeColor: tmpMember.typeId.typeColor,
-                typeUpdatedDate: tmpMember.typeUpdatedDate
-              });
+              // 성향 검사 일시가 null 이 아닐 경우
+              if (tmpMember.typeUpdatedDate !== null) {
+                todayMembersWithTypeColorWithDate.push({
+                  userName: tmpMember.userName,
+                  typeColor: tmpMember.typeId.typeColor,
+                  typeUpdatedDate: tmpMember.typeUpdatedDate
+                });
+              } else {
+                // 성향 검사 일시가 null 일 경우
+                todayMembersWithTypeColorNoDate.push({
+                  userName: tmpMember.userName,
+                  typeColor: tmpMember.typeId.typeColor,
+                  typeUpdatedDate: tmpMember.typeUpdatedDate
+                });
+              }
 
               // 오늘의 임시 담당자와 고정 담당자 비교
               if (
@@ -1173,11 +1187,21 @@ const getRuleInfoAtRuleHome = async (
             rule.ruleMembers.map(async (member: any) => {
               // 오늘 요일의 고정담당이 존재할 경우
               if (member.userId != null && member.day.includes(dayjs().day())) {
-                todayMembersWithTypeColorWithDate.push({
-                  userName: member.userId.userName,
-                  typeColor: member.userId.typeId.typeColor,
-                  typeUpdatedDate: member.typeUpdatedDate
-                });
+                // 성향 검사 일시가 null 이 아닐 경우
+                if (member.userId.typeUpdatedDate !== null) {
+                  todayMembersWithTypeColorWithDate.push({
+                    userName: member.userId.userName,
+                    typeColor: member.userId.typeId.typeColor,
+                    typeUpdatedDate: member.typeUpdatedDate
+                  });
+                } else {
+                  // 성향 검사 일시가 null 일 경우
+                  todayMembersWithTypeColorNoDate.push({
+                    userName: member.userId.userName,
+                    typeColor: member.userId.typeId.typeColor,
+                    typeUpdatedDate: member.typeUpdatedDate
+                  });
+                }
 
                 const checks = await Check.find({
                   ruleId: rule._id,
@@ -1207,6 +1231,10 @@ const getRuleInfoAtRuleHome = async (
             checkCnt = 0; // 다시 초기화
           }
         }
+
+        const todayMemberAllWithDate = todayMembersWithTypeColorWithDate.concat(
+          todayMembersWithTypeColorNoDate
+        );
 
         // 성향 오름차순으로 정렬
         todayMembersWithTypeColorWithDate.sort((before, current) => {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #82

## 🔑 Key Changes
1. 규칙 2/3구현을 도와주신 서버 파트원들에게 감사인사를 드립니다. 포항항 하우스서버 체고. ❤️‍🔥
2. 규칙의 담당자들이 체크를 했는지에 따라 체크 여부를 보내주는 부분을 추가하였습니다.
3. 규칙 카테고리 조회도 포함하였습니다.

## 📢 To Reviewers
- 콘솔을 하도 찍어서 지우긴 했지만 console.log() 있는지 확인 부탁드립니다... 
- 체크 부분 로직도 살펴봐주심 감사하겠습니다...
