### PR TITLE
규칙 별 카테고리 조회 api 수정

### DIFF
--- a/src/services/RuleService.ts
+++ b/src/services/RuleService.ts
@@ -691,13 +691,10 @@ const getRulesByCategoryId = async (
           await Promise.all(
             tmpRule.ruleMembers.map(async (ruleMember: any) => {
               if (ruleMember.userId !== null) {
-                // 성향 검사 일시가 null 이 아닐 경우 -> 성향 존재한다는 것
-                if (ruleMember.userId.typeUpdateDate !== null) {
-                  typeColorsWithDate.push({
-                    typeColor: ruleMember.userId.typeId.typeColor,
-                    typeUpdatedDate: ruleMember.userId.typeUpdatedDate
-                  });
-                }
+                typeColorsWithDate.push({
+                  typeColor: ruleMember.userId.typeId.typeColor,
+                  typeUpdatedDate: ruleMember.userId.typeUpdatedDate
+                });
               }
             })
           );


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #116 

## 🔑 Key Changes
1. 규칙 별 카테고리 조회 api 수정

## 📢 To Reviewers
- 규칙 별 카테고리 조회 api에서 유저 성향 타입 필터링 하지 말고 다 보내도록 수정
