### PR TITLE
[fix] 규칙 홈 조회 - 성향 테스트 한 사람은 앞으로 오름차순 정렬 / 안한 사람은 뒤로 변경

### DIFF
--- a/src/services/rule/RuleRetrieveService.ts
+++ b/src/services/rule/RuleRetrieveService.ts
@@ -763,10 +763,6 @@ const getRuleInfoAtRuleHome = async (
           }
         }
 
-        const todayMemberAllWithDate = todayMembersWithTypeColorWithDate.concat(
-          todayMembersWithTypeColorNoDate
-        );
-
         // 성향 오름차순으로 정렬
         todayMembersWithTypeColorWithDate.sort((before, current) => {
           return dayjs(before.typeUpdatedDate).isAfter(
@@ -776,12 +772,15 @@ const getRuleInfoAtRuleHome = async (
             : -1;
         });
 
+        // 규칙 리스트 : 성향 테스트한 사람(시간 기준, 오름차순 정렬) + 성향 테스트를 안한 사람
+        const todayMemberAllWithDate = todayMembersWithTypeColorWithDate.concat(
+          todayMembersWithTypeColorNoDate
+        );
+
         const todayMembersWithTypeColor: TodayMembersWithTypeColor[] =
-          todayMembersWithTypeColorWithDate.map(
-            ({ typeUpdatedDate, ...rest }) => {
-              return rest;
-            }
-          );
+          todayMemberAllWithDate.map(({ typeUpdatedDate, ...rest }) => {
+            return rest;
+          });
 
         todayTodoRulesWithDate.push({
           _id: rule._id,

--- a/src/services/rule/RuleRetrieveService.ts
+++ b/src/services/rule/RuleRetrieveService.ts
@@ -633,8 +633,6 @@ const getRuleInfoAtRuleHome = async (
         const originalTodayMembers: string[] = [];
         await Promise.all(
           rule.ruleMembers.map(async (ruleMember: any) => {
-            console.log(ruleMember.userId);
-            console.log(ruleMember.day);
             if (ruleMember.day.includes(dayjs().day())) {
               originalTodayMembers.push(ruleMember.userId);
             }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #155

## 🔑 Key Changes
1. console.log() 삭제
2. 규칙 홈 조회 시 성향 테스트 안한 사람 뒤로 넣기
   - 배열을 선언해두고 쓰진 않았더라구요 ㅎㅎ ........ 
   - 위치를 옮기고 사용하도록 바꿨습니다. 
   - 지현이가 데이터 넣어달라했는데 안떠서 발견한 휴먼에러
