### PR TITLE
[fix] 이벤트 조회 시, 방의 모든 참여자를 보여주되 이벤트 참여자만 체크 구분 추가

### DIFF
--- a/src/interfaces/event/response/EventResponseDto.ts
+++ b/src/interfaces/event/response/EventResponseDto.ts
@@ -10,6 +10,7 @@ export interface EventResponseDto extends PostBaseResponseDto {
 export interface UserType extends PostBaseResponseDto {
   userName: string;
   typeColor: string;
+  isChecked: boolean;
 }
 export interface UserTypeWithDate extends UserType {
   typeUpdatedDate: Date;

--- a/src/services/event/EventRetrieveService.ts
+++ b/src/services/event/EventRetrieveService.ts
@@ -45,10 +45,16 @@ const getEvent = async (
     const participantsNoDate: UserTypeWithDate[] = [];
     await Promise.all(
       usersInRoom.map(async (user: any) => {
+        let isChecked: boolean = event.participantsId.includes(
+          user._id.toString()
+        )
+          ? true
+          : false;
         if (user.tmpUpdatedDate != null) {
           participantsWithDate.push({
             _id: user._id,
             userName: user.userName,
+            isChecked: isChecked,
             typeColor: user.typeId.typeColor,
             typeUpdatedDate: user.typeUpdatedDate
           });
@@ -56,6 +62,7 @@ const getEvent = async (
           participantsNoDate.push({
             _id: user._id,
             userName: user.userName,
+            isChecked: isChecked,
             typeColor: user.typeId.typeColor,
             typeUpdatedDate: user.typeUpdatedDate
           });

--- a/src/services/event/EventService.ts
+++ b/src/services/event/EventService.ts
@@ -110,9 +110,12 @@ const updateEvent = async (
       participants.push(user.toString());
     });
 
-    eventUpdateDto.date = dayjs(eventUpdateDto.date).format('YYYY-MM-DD');
-
-    await Event.findByIdAndUpdate(eventId, eventUpdateDto);
+    await Event.findByIdAndUpdate(eventId, {
+      eventName: eventUpdateDto.eventName,
+      eventIcon: eventUpdateDto.eventIcon,
+      date: dayjs(eventUpdateDto.date).format('YYYY-MM-DD'),
+      participantsId: participants
+    });
 
     const data: EventUpdateResponseDto = {
       _id: event._id,


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #160

## 🔑 Key Changes
1. 클라 요청에 따라 방의 모든 참여자를 보여주되, 이벤트 참여자만 체크 구분되도록 변경하였습니다. 
