### PR TITLE
#168 [fix] dayjs().isSame() 검사 시, 'day' 옵션 달기

### DIFF
--- a/src/services/rule/RuleService.ts
+++ b/src/services/rule/RuleService.ts
@@ -598,7 +598,7 @@ const updateMyRuleTodoCheck = async (
         let isAlreadyUnChecked: boolean = true;
 
         for (const check of checks) {
-          if (dayjs(check.date).isSame(dayjs().format('YYYY-MM-DD'))) {
+          if (dayjs(check.date).isSame(dayjs().format('YYYY-MM-DD'), 'day')) {
             isAlreadyUnChecked = false;
             break;
           }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #168

## 🔑 Key Changes
false -> false 시 잘못된 요청은 정상적으로 가는데 
false -> true 로 요청 시 변경이 안되는 문제가 발생해서 콘솔 찍어보니 isSame()은 false로 나오더라구요 ....
그래서 isSame 인자에 'day'를 추가해서 년/월/일끼리만 비교하도록 변경하였습니다!
