### PR TITLE
방 참여자 조회 관련 api 에서 정렬 수정

### DIFF
--- a/src/interfaces/rule/response/RuleCreateInfoResponseDto.ts
+++ b/src/interfaces/rule/response/RuleCreateInfoResponseDto.ts
@@ -15,3 +15,7 @@ export interface Homies {
   userName: string;
   typeColor: string;
 }
+
+export interface HomiesWithDate extends Homies {
+  typeUpdatedDate: Date;
+}

--- a/src/services/rule/RuleRetrieveService.ts
+++ b/src/services/rule/RuleRetrieveService.ts
@@ -182,19 +182,19 @@ const getRuleCreateInfo = async (
       .populate('typeId', 'typeColor')
       .sort({ typeUpdatedDate: 1 });
 
-    const HomiesWithDate: HomiesWithDate[] = [];
-    const HomiesWithNullDate: HomiesWithDate[] = [];
+    const homiesWithDate: HomiesWithDate[] = [];
+    const homiesWithNullDate: HomiesWithDate[] = [];
     await Promise.all(
       tmpHomies.map(async (homie: any) => {
         if (homie.typeUpdatedDate != null) {
-          HomiesWithDate.push({
+          homiesWithDate.push({
             _id: homie._id,
             userName: homie.userName,
             typeColor: homie.typeId.typeColor,
             typeUpdatedDate: homie.typeUpdatedDate
           });
         } else {
-          HomiesWithNullDate.push({
+          homiesWithNullDate.push({
             _id: homie._id,
             userName: homie.userName,
             typeColor: homie.typeId.typeColor,
@@ -204,14 +204,17 @@ const getRuleCreateInfo = async (
       })
     );
 
-    const homiesWithDate: HomiesWithDate[] =
-      HomiesWithDate.concat(HomiesWithNullDate);
-
-    const homies: Homies[] = homiesWithDate.map(
-      ({ typeUpdatedDate, ...rest }) => {
+    const homies: Homies[] = homiesWithDate
+      .concat(homiesWithNullDate)
+      .map(({ typeUpdatedDate, ...rest }) => {
         return rest;
-      }
-    );
+      });
+
+    // const homies: Homies[] = homiesWithDate.map(
+    //   ({ typeUpdatedDate, ...rest }) => {
+    //     return rest;
+    //   }
+    // );
 
     const data: RuleCreateInfoResponseDto = {
       ruleCategories: ruleCategories,
@@ -409,16 +412,18 @@ const getHomiesWithIsTmpMember = async (
     // 참가하고 있는 방의 규칙이 아니면 접근 불가능
     await RuleServiceUtils.checkForbiddenRule(user.roomId, rule.roomId);
 
-    const homies = await User.find({
+    const tmpHomies = await User.find({
       roomId: roomId
-    }).populate('typeId', 'typeColor');
+    })
+      .populate('typeId', 'typeColor')
+      .sort({ typeUpdatedDate: 1 });
 
     let homiesWithIsTmpMembersWithDate: HomiesWithIsTmpMemberWithDate[];
 
     // tmpUpdatedDate === 오늘 -> tmpRuleMembers에 있는 유저는 isChecked = true
     if (dayjs().isSame(rule.tmpUpdatedDate, 'day')) {
       homiesWithIsTmpMembersWithDate = await Promise.all(
-        homies.map(async (homie: any) => {
+        tmpHomies.map(async (homie: any) => {
           let isChecked: boolean = false;
           for (const userId of rule.tmpRuleMembers) {
             if (userId.equals(homie._id)) {
@@ -431,7 +436,7 @@ const getHomiesWithIsTmpMember = async (
             _id: homie._id as string,
             userName: homie.userName as string,
             isChecked: isChecked,
-            typeColor: (homie.typeId as any).typeColor as string,
+            typeColor: homie.typeId.typeColor as string,
             typeUpdatedDate: homie.typeUpdatedDate
           };
         })
@@ -439,7 +444,7 @@ const getHomiesWithIsTmpMember = async (
     } else {
       // tmpUpdatedDate !== 오늘 -> 고정 담당자 리스트에 있는 유저만 isChecked = true
       homiesWithIsTmpMembersWithDate = await Promise.all(
-        homies.map(async (homie: any) => {
+        tmpHomies.map(async (homie: any) => {
           let isChecked: boolean = false;
 
           for (const member of rule.ruleMembers) {
@@ -456,29 +461,46 @@ const getHomiesWithIsTmpMember = async (
             _id: homie._id as string,
             userName: homie.userName as string,
             isChecked: isChecked,
-            typeColor: (homie.typeId as any).typeColor as string,
+            typeColor: homie.typeId.typeColor as string,
             typeUpdatedDate: homie.typeUpdatedDate
           };
         })
       );
     }
 
-    homiesWithIsTmpMembersWithDate.sort((before, current) => {
-      return dayjs(before.typeUpdatedDate).isAfter(
-        dayjs(current.typeUpdatedDate)
-      )
-        ? 1
-        : -1;
-    });
+    const homiesWithIsCheckedWithDate: HomiesWithIsTmpMemberWithDate[] = [];
+    const homiesWithIsCheckedWithNullDate: HomiesWithIsTmpMemberWithDate[] = [];
+    await Promise.all(
+      homiesWithIsTmpMembersWithDate.map(async (homie: any) => {
+        if (homie.typeUpdatedDate != null) {
+          homiesWithIsCheckedWithDate.push({
+            _id: homie._id,
+            userName: homie.userName,
+            isChecked: homie.isChecked,
+            typeColor: homie.typeColor,
+            typeUpdatedDate: homie.typeUpdatedDate
+          });
+        } else {
+          homiesWithIsCheckedWithNullDate.push({
+            _id: homie._id,
+            userName: homie.userName,
+            isChecked: homie.isChecked,
+            typeColor: homie.typeColor,
+            typeUpdatedDate: homie.typeUpdatedDate
+          });
+        }
+      })
+    );
 
-    const homiesWithIsTmpMembers: HomiesWithIsTmpMember[] =
-      homiesWithIsTmpMembersWithDate.map(({ typeUpdatedDate, ...rest }) => {
+    const homies: HomiesWithIsTmpMember[] = homiesWithIsCheckedWithDate
+      .concat(homiesWithIsCheckedWithNullDate)
+      .map(({ typeUpdatedDate, ...rest }) => {
         return rest;
       });
 
     const data: HomiesWithIsTmpMemberResponseDto = {
       _id: ruleId,
-      homies: homiesWithIsTmpMembers
+      homies: homies
     };
 
     return data;

--- a/src/services/rule/RuleRetrieveService.ts
+++ b/src/services/rule/RuleRetrieveService.ts
@@ -210,12 +210,6 @@ const getRuleCreateInfo = async (
         return rest;
       });
 
-    // const homies: Homies[] = homiesWithDate.map(
-    //   ({ typeUpdatedDate, ...rest }) => {
-    //     return rest;
-    //   }
-    // );
-
     const data: RuleCreateInfoResponseDto = {
       ruleCategories: ruleCategories,
       homies: homies

--- a/src/services/rule/RuleRetrieveService.ts
+++ b/src/services/rule/RuleRetrieveService.ts
@@ -6,6 +6,7 @@ import {
 } from '../../interfaces/rule/response/HomiesWithIsTmpMemberResponseDto';
 import {
   Homies,
+  HomiesWithDate,
   RuleCategories,
   RuleCreateInfoResponseDto
 } from '../../interfaces/rule/response/RuleCreateInfoResponseDto';
@@ -177,18 +178,39 @@ const getRuleCreateInfo = async (
 
     const tmpHomies = await User.find({
       roomId: roomId
-    }).populate('typeId', 'typeColor');
+    })
+      .populate('typeId', 'typeColor')
+      .sort({ typeUpdatedDate: 1 });
 
-    const homies: Homies[] = await Promise.all(
+    const HomiesWithDate: HomiesWithDate[] = [];
+    const HomiesWithNullDate: HomiesWithDate[] = [];
+    await Promise.all(
       tmpHomies.map(async (homie: any) => {
-        const result = {
-          _id: homie._id,
-          userName: homie.userName,
-          typeColor: homie.typeId.typeColor
-        };
-
-        return result;
+        if (homie.typeUpdatedDate != null) {
+          HomiesWithDate.push({
+            _id: homie._id,
+            userName: homie.userName,
+            typeColor: homie.typeId.typeColor,
+            typeUpdatedDate: homie.typeUpdatedDate
+          });
+        } else {
+          HomiesWithNullDate.push({
+            _id: homie._id,
+            userName: homie.userName,
+            typeColor: homie.typeId.typeColor,
+            typeUpdatedDate: homie.typeUpdatedDate
+          });
+        }
       })
+    );
+
+    const homiesWithDate: HomiesWithDate[] =
+      HomiesWithDate.concat(HomiesWithNullDate);
+
+    const homies: Homies[] = homiesWithDate.map(
+      ({ typeUpdatedDate, ...rest }) => {
+        return rest;
+      }
     );
 
     const data: RuleCreateInfoResponseDto = {


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #194

## 🔑 Key Changes
1. 방 참여자 조회 관련 api 에서 정렬 수정
   - 규칙 생성 시 방참여자 조회
   - 임시 담당자 설정 시 방참여자 조회

## 📢 To Reviewers
- 정말 수정은 끝이기를 바라며 ㅋㅋㅋㅋㅋㅋ
